### PR TITLE
Fix `#setRecordAllObjects`

### DIFF
--- a/packages/MessageSendRecorder.package/MessageSendRecorder.class/instance/setRecordAllObjects.st
+++ b/packages/MessageSendRecorder.package/MessageSendRecorder.class/instance/setRecordAllObjects.st
@@ -2,10 +2,10 @@ initialization
 setRecordAllObjects
 	"Hold on to all object pointers for receivers, arguments, and return values."
 	
-	self setBefore: {[:record :rcvr :args |
+	self setBefore: {[:record :rcvr :args :ctx |
 			record extension
 				receiverObject: rcvr;
 				argumentObjects: args.]}
-		after: {[:record :rcvr :args :result |
+		after: {[:record :rcvr :args :result :ctx |
 			record extension
 				returnObject: result]}.

--- a/packages/MessageSendRecorder.package/MessageSendRecorder.class/methodProperties.json
+++ b/packages/MessageSendRecorder.package/MessageSendRecorder.class/methodProperties.json
@@ -48,7 +48,7 @@
 		"setBefore:after:" : "mt 9/1/2020 12:26",
 		"setMessageSend:" : "mt 7/16/2020 12:39",
 		"setMessageSendArguments:" : "mt 7/28/2020 10:39",
-		"setRecordAllObjects" : "mt 7/28/2020 11:11",
+		"setRecordAllObjects" : "ct 10/21/2021 01:23",
 		"shouldRecord" : "mt 7/24/2020 15:25",
 		"topRecord" : "mt 7/15/2020 16:21",
 		"topRecord:" : "mt 7/15/2020 16:21",


### PR DESCRIPTION
Same reason as https://github.com/hpi-swa/MessageSendRecorder/pull/8. Currently, this selector is broken. Note that I still would like to have `#cull:cull:cull:cull:cull:` for these blocks (see https://github.com/hpi-swa/MessageSendRecorder/pull/11), but even then, specify all arguments here for maximum efficiency.